### PR TITLE
Add 4-button combo for recalibration with countdown

### DIFF
--- a/Rp2040Lcd.py
+++ b/Rp2040Lcd.py
@@ -375,6 +375,25 @@ class LCD_1inch28(framebuf.FrameBuffer):
         self.lx_euclid_config.state_lock.acquire()
         local_state = self.lx_euclid_config.state
         self.lx_euclid_config.state_lock.release()
+
+        if local_state == LxEuclidConstant.STATE_CALIBRATION_COUNTDOWN:
+            self.fill(self.black) # Clear screen
+            remaining_ms = self.lx_euclid_config.calibration_countdown_start_ms + self.lx_euclid_config.calibration_countdown_duration_ms - ticks_ms()
+            if remaining_ms < 0:
+                remaining_ms = 0
+
+            seconds_to_display = (remaining_ms + 999) // 1000 # Ceil division
+
+            countdown_text = str(seconds_to_display)
+
+            if self.font_writer_freesans20:
+                text_width = self.font_writer_freesans20.stringlen(countdown_text)
+                text_x = (self.width - text_width) // 2
+                text_y = (self.height - self.font_writer_freesans20.char_height) // 2
+                self.font_writer_freesans20.text(countdown_text, text_x, text_y, self.white)
+
+            self.show()
+            return # Exit after handling countdown display
         
         if local_state == LxEuclidConstant.STATE_TEST:            
             angle_outer = 90-self.lx_euclid_config.lx_hardware.capacitives_circles.outer_circle_angle

--- a/lxEuclidConfig.py
+++ b/lxEuclidConfig.py
@@ -511,6 +511,7 @@ class LxEuclidConstant:
     STATE_PARAM_PADS = const(9)
     STATE_CHANNEL_CONFIG = const(10)
     STATE_CHANNEL_CONFIG_SELECTION = const(11)
+    STATE_CALIBRATION_COUNTDOWN = const(12)
     STATE_TEST= const(100)
 
     EVENT_INIT = const(0)
@@ -638,6 +639,10 @@ class LxEuclidConfig:
             self.LCD.fill(self.LCD.black)
             self.LCD.show()
             self.LCD.init_display(self._flip)
+
+        self.calibration_countdown_start_ms = 0
+        self.calibration_countdown_duration_ms = 5000  # 5 seconds
+        self.previous_state_before_countdown = LxEuclidConstant.STATE_LIVE
             
     @property
     def flip(self):

--- a/lxHardware.py
+++ b/lxHardware.py
@@ -91,6 +91,7 @@ class LxHardware:
 
     BTN_SWITCHES_RISE = const(14)
     BTN_SWITCHES_FALL = const(15)
+    BTN_ALL_SWITCHES_RISE = const(16)
 
     EEPROM_ADDR = const(0x50)
 
@@ -113,6 +114,9 @@ class LxHardware:
                 HandlerEventData(LxHardware.BTN_SWITCHES_RISE, i))
             self.btn_switches_fall_event.append(
                 HandlerEventData(LxHardware.BTN_SWITCHES_FALL, i))
+
+        self.btn_all_switches_rise_event = HandlerEventData(LxHardware.BTN_ALL_SWITCHES_RISE)
+        self.all_switches_previously_pressed = False
 
         self.lxHardwareEventFifo = deque((), 20)
 
@@ -284,6 +288,19 @@ class LxHardware:
                         self.btn_switches_rise_event[index])
                 break
             index += 1
+
+        all_pressed = True
+        for status in self.btn_menu_pins_status:
+            if status != 0:
+                all_pressed = False
+                break
+
+        if all_pressed:
+            if not self.all_switches_previously_pressed:
+                self.lxHardwareEventFifo.append(self.btn_all_switches_rise_event)
+                self.all_switches_previously_pressed = True
+        else:
+            self.all_switches_previously_pressed = False
 
     def btn_menu_pin_change(self, pin):
         if self.btn_menu_pin_status == self.btn_menu_pin.value():

--- a/main.py
+++ b/main.py
@@ -143,6 +143,14 @@ def lxhardware_changed(handlerEventData):
         lx_euclid_config.on_event(
             LxEuclidConstant.EVENT_BTN_SWITCHES, handlerEventData.data)
         LCD.set_need_display()
+    elif event == lx_hardware.BTN_ALL_SWITCHES_RISE:
+        lx_euclid_config.previous_state_before_countdown = lx_euclid_config.state
+        lx_euclid_config.state = LxEuclidConstant.STATE_CALIBRATION_COUNTDOWN
+        lx_euclid_config.calibration_countdown_start_ms = ticks_ms()
+        lx_hardware.clear_sw_leds()
+        lx_hardware.clear_tap_led()
+        lx_hardware.clear_menu_led()
+        LCD.set_need_display()
     elif event == lx_hardware.BTN_MENU_RISE:
         tmp_time = ticks_ms()
         if (tmp_time - btn_menu_press) > DEBOUNCE_MS:
@@ -171,6 +179,19 @@ def display_thread():
             if not in_lxhardware_changed:
                 gc.collect()
                 lx_euclid_config.test_save_data_in_file()
+
+                if lx_euclid_config.state == LxEuclidConstant.STATE_CALIBRATION_COUNTDOWN:
+                    remaining_ms = lx_euclid_config.calibration_countdown_start_ms + lx_euclid_config.calibration_countdown_duration_ms - ticks_ms()
+                    if remaining_ms <= 0:
+                        # Countdown finished, trigger calibration
+                        lx_hardware.capacitives_circles.calibration_sensor()
+
+                        # Revert to the previous state
+                        lx_euclid_config.state = lx_euclid_config.previous_state_before_countdown
+
+                        # Ensure display updates to the new state
+                        LCD.set_need_display()
+
                 if LCD.get_need_flip():
                     gc.collect()
                     LCD.reset_need_flip()


### PR DESCRIPTION
This feature allows you to trigger a touch sensor recalibration by pressing all four track select buttons simultaneously.

When the combination is detected:
- A 5-second countdown is displayed on the screen, allowing you to move your hands away from the touch rings.
- After the countdown, the `calibration_sensor()` method for the capacitive touch circles is called.
- The device then returns to its previous operational state.

Modifications include:
- `lxHardware.py`: Added detection for the simultaneous press of all four track select buttons (`BTN_ALL_SWITCHES_RISE` event).
- `lxEuclidConfig.py`: Introduced a new state `STATE_CALIBRATION_COUNTDOWN` and variables to manage the countdown timing and previous state.
- `main.py`:
    - Handles the `BTN_ALL_SWITCHES_RISE` event to initiate the countdown state.
    - Triggers calibration and state reversion in the `display_thread` when the countdown completes.
- `Rp2040Lcd.py`: Implemented display logic to show the countdown timer when in `STATE_CALIBRATION_COUNTDOWN`.